### PR TITLE
Check buffer-size against would-be-rowcount

### DIFF
--- a/python/ecl3/core.cpp
+++ b/python/ecl3/core.cpp
@@ -342,7 +342,7 @@ py::object readall(
     expect("INTE", seqhdr.type);
 
     while (true) {
-        if ((rows - 1) * rowsize >= buffer.size()) {
+        if ((rows + 1) * rowsize >= buffer.size()) {
             buffer.resize(buffer.size() * 2);
         }
 


### PR DESCRIPTION
Off-by-ones are hard.

So a few structural changes around made so this one slipped through -
the correct check is to ensure that there is enough room in the buffer
for the record about-to-be-written, when checking if a resize is
necessary.